### PR TITLE
Add service-side support: inbound method calls, replies, and signal emission

### DIFF
--- a/lib/rebus.ex
+++ b/lib/rebus.ex
@@ -270,15 +270,23 @@ defmodule Rebus do
   """
   @spec reply(pid(), Rebus.Message.t(), [term()], String.t() | nil) :: :ok | {:error, term()}
   def reply(conn, %Rebus.Message{} = request, body \\ [], signature \\ nil) do
-    opts = [
-      reply_serial: request.serial,
-      destination: request.header_fields[:sender],
-      body: body,
-      flags: [:no_reply_expected]
-    ]
+    if no_reply_expected?(request) do
+      # The caller flagged the method call NO_REPLY_EXPECTED (e.g. org.bluez
+      # AdvertisementMonitor1.DeviceFound). Sending a method_return anyway is an
+      # unsolicited reply the bus policy rejects ("Rejected send message ...
+      # requested_reply=0"), so skip it.
+      :ok
+    else
+      opts = [
+        reply_serial: request.serial,
+        destination: request.header_fields[:sender],
+        body: body,
+        flags: [:no_reply_expected]
+      ]
 
-    opts = if signature, do: Keyword.put(opts, :signature, signature), else: opts
-    Rebus.Connection.send(conn, Rebus.Message.new!(:method_return, opts))
+      opts = if signature, do: Keyword.put(opts, :signature, signature), else: opts
+      Rebus.Connection.send(conn, Rebus.Message.new!(:method_return, opts))
+    end
   end
 
   @doc """
@@ -287,16 +295,24 @@ defmodule Rebus do
   """
   @spec reply_error(pid(), Rebus.Message.t(), String.t(), String.t()) :: :ok | {:error, term()}
   def reply_error(conn, %Rebus.Message{} = request, error_name, message) do
-    Rebus.Connection.send(
-      conn,
-      Rebus.Message.new!(:error,
-        error_name: error_name,
-        reply_serial: request.serial,
-        destination: request.header_fields[:sender],
-        body: [message],
-        signature: "s",
-        flags: [:no_reply_expected]
+    if no_reply_expected?(request) do
+      :ok
+    else
+      Rebus.Connection.send(
+        conn,
+        Rebus.Message.new!(:error,
+          error_name: error_name,
+          reply_serial: request.serial,
+          destination: request.header_fields[:sender],
+          body: [message],
+          signature: "s",
+          flags: [:no_reply_expected]
+        )
       )
-    )
+    end
+  end
+
+  defp no_reply_expected?(%Rebus.Message{flags: flags}) do
+    is_list(flags) and :no_reply_expected in flags
   end
 end

--- a/lib/rebus.ex
+++ b/lib/rebus.ex
@@ -315,4 +315,22 @@ defmodule Rebus do
   defp no_reply_expected?(%Rebus.Message{flags: flags}) do
     is_list(flags) and :no_reply_expected in flags
   end
+
+  @doc """
+  Emit a D-Bus `:signal` on `conn`.
+
+  `opts` are forwarded to `Rebus.Message.new!/2` and must include `:path`,
+  `:interface`, and `:member`. Pass `:body` and `:signature` when the signal
+  carries arguments, and an optional `:destination` to direct it at one peer.
+
+  Unlike `reply/4`, a signal is fire-and-forget: the transport skips the
+  pending-reply table, so there is nothing to await — this returns `:ok` as
+  soon as the frame is written. Used to push GATT notifications, e.g. a
+  `org.freedesktop.DBus.Properties.PropertiesChanged` on an exported
+  characteristic object.
+  """
+  @spec emit_signal(pid(), keyword()) :: :ok | {:error, term()}
+  def emit_signal(conn, opts) when is_pid(conn) and is_list(opts) do
+    Rebus.Connection.send(conn, Rebus.Message.new!(:signal, opts))
+  end
 end

--- a/lib/rebus.ex
+++ b/lib/rebus.ex
@@ -248,4 +248,55 @@ defmodule Rebus do
   subsequent calls will simply return `:ok` without error.
   """
   defdelegate delete_signal_handler(conn, ref), to: Rebus.Connection
+
+  # ── Service-side API (fork addition: bbangert/rebus, branch dbus-service) ──
+  #
+  # Upstream rebus is a pure client. These let a process act as a D-Bus
+  # *service* — receive inbound method calls and reply — which is required to
+  # export objects (e.g. an org.bluez AdvertisementMonitor for passive BLE
+  # scanning).
+
+  @doc """
+  Register `handler` to receive inbound method calls on `conn` as
+  `{:dbus_call, %Rebus.Message{type: :method_call}}` messages. The handler
+  replies with `reply/4` or `reply_error/4`.
+  """
+  defdelegate set_method_handler(conn, handler), to: Rebus.Connection
+
+  @doc """
+  Reply to an inbound method call `request` with a `:method_return`. `body` is
+  the reply arguments (default none); pass `signature` when the body is
+  non-empty (e.g. `"a{sv}"`).
+  """
+  @spec reply(pid(), Rebus.Message.t(), [term()], String.t() | nil) :: :ok | {:error, term()}
+  def reply(conn, %Rebus.Message{} = request, body \\ [], signature \\ nil) do
+    opts = [
+      reply_serial: request.serial,
+      destination: request.header_fields[:sender],
+      body: body,
+      flags: [:no_reply_expected]
+    ]
+
+    opts = if signature, do: Keyword.put(opts, :signature, signature), else: opts
+    Rebus.Connection.send(conn, Rebus.Message.new!(:method_return, opts))
+  end
+
+  @doc """
+  Reply to an inbound method call `request` with a D-Bus error
+  (e.g. `"org.freedesktop.DBus.Error.UnknownMethod"`).
+  """
+  @spec reply_error(pid(), Rebus.Message.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def reply_error(conn, %Rebus.Message{} = request, error_name, message) do
+    Rebus.Connection.send(
+      conn,
+      Rebus.Message.new!(:error,
+        error_name: error_name,
+        reply_serial: request.serial,
+        destination: request.header_fields[:sender],
+        body: [message],
+        signature: "s",
+        flags: [:no_reply_expected]
+      )
+    )
+  end
 end

--- a/lib/rebus/connection.ex
+++ b/lib/rebus/connection.ex
@@ -20,6 +20,16 @@ defmodule Rebus.Connection do
     GenServer.call(conn, {:delete_signal_handler, ref})
   end
 
+  @doc """
+  Register a process to receive inbound method calls (fork addition). The
+  process receives `{:dbus_call, %Rebus.Message{type: :method_call}}` messages
+  and should reply via `Rebus.reply/4` / `Rebus.reply_error/4`.
+  """
+  @spec set_method_handler(pid(), pid()) :: :ok
+  def set_method_handler(conn, handler) when is_pid(conn) and is_pid(handler) do
+    GenServer.call(conn, {:set_method_handler, handler})
+  end
+
   @spec start_link(keyword()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
@@ -33,6 +43,12 @@ defmodule Rebus.Connection do
     field :name, binary() | nil, default: nil
     field :serial, non_neg_integer(), default: 1
     field :pending, %{non_neg_integer() => :gen_statem.from()}, default: %{}
+    # Downstream fork addition (bbangert/rebus, branch dbus-service): a process
+    # that receives inbound method calls as `{:dbus_call, %Message{}}` so this
+    # connection can act as a D-Bus *service* (needed to export an org.bluez
+    # AdvertisementMonitor for passive scanning). Upstream rebus is client-only
+    # and would crash on an inbound method call.
+    field :method_handler, pid() | nil, default: nil
   end
 
   @impl true
@@ -157,6 +173,10 @@ defmodule Rebus.Connection do
     {:reply, :ok, state}
   end
 
+  def handle_call({:set_method_handler, handler}, _from, %__MODULE__{} = state) do
+    {:reply, :ok, %{state | method_handler: handler}}
+  end
+
   defp parse(data, %__MODULE__{} = state) do
     case Message.parse(data) do
       {:ok, %Message{header_fields: %{reply_serial: 1}} = msg, rest} when is_nil(state.name) ->
@@ -168,6 +188,9 @@ defmodule Rebus.Connection do
       {:ok, %Message{type: :signal} = msg, rest} ->
         parse(rest, notify(msg, state))
 
+      {:ok, %Message{type: :method_call} = msg, rest} ->
+        parse(rest, dispatch_call(msg, state))
+
       nil ->
         # Incomplete message, store data for next recv
         {:noreply, %{state | prev: data}, {:continue, :recv}}
@@ -176,6 +199,19 @@ defmodule Rebus.Connection do
         {:stop, reason}
     end
   end
+
+  # Fork addition: deliver an inbound method call to the registered handler.
+  # With no handler set, drop it (the service registers its handler before it
+  # exposes any object, so org.bluez never calls us unhandled).
+  defp dispatch_call(%Message{} = msg, %__MODULE__{method_handler: pid} = state)
+       when is_pid(pid) do
+    # Kernel.send/2 explicitly: this module defines a local send/2 (the
+    # client-side method-call sender), which would otherwise shadow it.
+    Kernel.send(pid, {:dbus_call, msg})
+    state
+  end
+
+  defp dispatch_call(%Message{}, %__MODULE__{} = state), do: state
 
   defp notify(%Message{} = msg, %__MODULE__{name: name} = state) do
     case msg do

--- a/test/rebus/encoder_test.exs
+++ b/test/rebus/encoder_test.exs
@@ -1,6 +1,7 @@
 defmodule Rebus.EncoderTest do
   use ExUnit.Case, async: true
 
+  alias Rebus.Decoder
   alias Rebus.Encoder
 
   describe "basic types" do
@@ -169,6 +170,31 @@ defmodule Rebus.EncoderTest do
       assert rest8 == <<>>
       # Just verify we got some reasonable length
       assert array_length > 0
+    end
+
+    # Regression: a GATT Properties.GetAll can legitimately return an empty
+    # `a{sv}`, and a notification body carries an empty trailing `as`. The
+    # existing client never emits an empty container, so guard the length +
+    # alignment accounting here. (Spec: array = UINT32 length of element data
+    # only, then padding to the element's alignment boundary even when empty.)
+    test "encodes empty a{sv} as zero-length with 8-byte alignment padding" do
+      binary = "a{sv}" |> then(&Encoder.encode(&1, [[]])) |> IO.iodata_to_binary()
+
+      # length field = 0 (no element bytes), then 4 bytes padding to the
+      # dict-entry 8-byte boundary. Length must NOT count the padding.
+      assert binary == <<0, 0, 0, 0, 0, 0, 0, 0>>
+      assert Decoder.decode("a{sv}", binary) == [[]]
+    end
+
+    test "encodes empty as / ay as a bare zero-length field" do
+      # string/byte elements align to 4/1, so an empty array is just the length.
+      as = "as" |> then(&Encoder.encode(&1, [[]])) |> IO.iodata_to_binary()
+      ay = "ay" |> then(&Encoder.encode(&1, [[]])) |> IO.iodata_to_binary()
+
+      assert as == <<0, 0, 0, 0>>
+      assert ay == <<0, 0, 0, 0>>
+      assert Decoder.decode("as", as) == [[]]
+      assert Decoder.decode("ay", ay) == [[]]
     end
   end
 

--- a/test/rebus_test.exs
+++ b/test/rebus_test.exs
@@ -170,6 +170,36 @@ defmodule RebusTest do
 
       assert_receive {^ref, %Message{body: ["foobar"]}}
     end
+
+    test "emit_signal/2 emits a fire-and-forget signal", %{cli: cli, svr: svr} do
+      # A realistic GATT notification body (PropertiesChanged with an `ay` Value).
+      # emit_signal returns :ok synchronously: if the :signal were treated like a
+      # method_call it would land in the pending-reply table and block until a
+      # reply that never comes. Returning :ok proves it skips that table.
+      assert :ok =
+               Rebus.emit_signal(cli,
+                 path: "/up/improv/service0/char0",
+                 interface: "org.freedesktop.DBus.Properties",
+                 member: "PropertiesChanged",
+                 signature: "sa{sv}as",
+                 body: [
+                   "org.bluez.GattCharacteristic1",
+                   [{"Value", {"ay", [1, 2, 3]}}],
+                   []
+                 ]
+               )
+
+      assert_receive {^svr, %Message{type: :signal} = rcvd}
+      assert rcvd.header_fields[:path] == "/up/improv/service0/char0"
+      assert rcvd.header_fields[:interface] == "org.freedesktop.DBus.Properties"
+      assert rcvd.header_fields[:member] == "PropertiesChanged"
+
+      assert [
+               "org.bluez.GattCharacteristic1",
+               [{"Value", {"ay", [1, 2, 3]}}],
+               []
+             ] = rcvd.body
+    end
   end
 
   defp server_setup(_) do


### PR DESCRIPTION
Rebus is currently a pure client — the connection parser has no `:method_call` branch, so an inbound method call crashes the connection (`CaseClauseError`) and a process can't export D-Bus objects. This PR adds the minimal service-side surface, as three commits:

1. **Inbound method calls + replies** — `Rebus.Connection` gains a `:method_call` parse clause that forwards the message to a registered handler pid as `{:dbus_call, %Message{}}` (dropped when no handler is set, preserving today's client-only behavior), plus `Rebus.set_method_handler/2`, `Rebus.reply/4` (`:method_return`), and `Rebus.reply_error/4` — the reply helpers build headers from the request's serial + sender.
2. **`NO_REPLY_EXPECTED` handling** — `reply/4` and `reply_error/4` no-op when the caller flagged the call `NO_REPLY_EXPECTED`; an unsolicited reply violates bus policy (`"Rejected send message ... requested_reply=0"`) and floods the daemon log.
3. **`Rebus.emit_signal/2`** — public fire-and-forget signal emission, so services can send e.g. `PropertiesChanged` without reaching into the `@moduledoc false` `Connection` module. Includes a round-trip test and a regression test for empty `a{sv}`/`as`/`ay` container marshalling.

**Motivation:** exporting an `org.bluez.AdvertisementMonitor1` object — BlueZ's passive BLE scanning API calls *into* the client (`GetManagedObjects`, `Activate`, `DeviceFound`), so a scanner must be a service too. Same story for GATT servers and agents.

**Field history:** these commits have been running in production since June as part of an ESPHome Bluetooth proxy on Raspberry Pi hardware ([universal_proxy](https://github.com/bbangert/universal_proxy), and now the extracted [bluez](https://github.com/bbangert/bluez) library) — passive/active scanning, GATT server + client, and pairing-agent traffic against bluetoothd 5.79.

These changes were built with Claude and reviewed by a human before and during their production use.

Purely additive — no existing API changes, all existing tests pass. Happy to adapt the shape to where #3 (explicit signatures at the low level) and #5 (proxy objects) take the API; these helpers are deliberately low-level and orthogonal to both.